### PR TITLE
Add a url keyword or argument to Agent#initialize

### DIFF
--- a/lib/ronin/web/browser.rb
+++ b/lib/ronin/web/browser.rb
@@ -117,6 +117,9 @@ module Ronin
       # @option kwargs [Boolean] headless (true)
       #   Controls whether the browser will start in headless or visible mode.
       #
+      # @option kwargs [String, nil] url
+      #   Provides url for browser to navigate to after initialization.
+      #
       # @option kwargs [String, URI::HTTP, Addressible::URI, Hash, nil] :proxy (Ronin::Support::Network::HTTP.proxy)
       #   The proxy to send all browser requests through.
       #

--- a/lib/ronin/web/browser/agent.rb
+++ b/lib/ronin/web/browser/agent.rb
@@ -39,7 +39,7 @@ module Ronin
         attr_reader :proxy
 
         #
-        # Initializes the browser agent.
+        # Initializes the browser agent, and optionally navigates to the url, if provided.
         #
         # @param [Boolean] visible
         #   Controls whether the browser will start in visible or headless mode.
@@ -50,12 +50,16 @@ module Ronin
         # @param [String, URI::HTTP, Addressible::URI, Hash, nil] proxy
         #   The proxy to send all browser requests through.
         #
+        # @param [String, nil] url
+        #   Provides url for browser to navigate to after initialization.
+        #
         # @param [Hash{Symbol => Object}] kwargs
         #   Additional keyword arguments for `Ferrum::Browser#initialize`.
         #
         def initialize(visible:  false,
                        headless: !visible,
                        proxy:    Ronin::Support::Network::HTTP.proxy,
+                       url:      nil,
                        **kwargs)
           proxy = case proxy
                   when Hash, nil then proxy
@@ -83,6 +87,7 @@ module Ronin
           @proxy    = proxy
 
           super(headless: headless, proxy: proxy, **kwargs)
+          go_to(url) if url
         end
 
         #

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -21,6 +21,18 @@ describe Ronin::Web::Browser::Agent do
       after { Ronin::Support::Network::HTTP.proxy = nil }
     end
 
+    context "when given the url: keyword argument" do
+      let(:url) { 'https://example.com/' }
+      subject   { described_class.new(url: url) }
+
+      it 'navigates to the url' do
+        expect(subject.url).to eql(url)
+        expect(subject.current_url).to eql(url)
+      end
+
+      after { subject.quit }
+    end
+
     context "when given the proxy: keyword argument" do
       let(:proxy_host) { 'example.com' }
       let(:proxy_port) { 8080 }


### PR DESCRIPTION
Adds the url: kwarg to the Ronin::Web::Browers::Agent initializer, as outlined in issue #16. Upon initialization the browser will navigate to this url.

Hope this contribution is useful - did my best to conform to code conventions across the rest of the repo. Please do let me know of any changes that are needed. Eager to contribute in any way that might be helpful 👍   