### PR TITLE
Add cookie kwarg to Ronin::Web::Browser::Agent initializer

### DIFF
--- a/lib/ronin/web/browser.rb
+++ b/lib/ronin/web/browser.rb
@@ -117,6 +117,9 @@ module Ronin
       # @option kwargs [Boolean] headless (true)
       #   Controls whether the browser will start in headless or visible mode.
       #
+      # @option kwargs [Hash{Symbol => Object}, Ferrum::Cookies::Cookie, nil] cookie
+      #   Provides cookie to set for browser after initialization.
+      #
       # @option kwargs [String, nil] url
       #   Provides url for browser to navigate to after initialization.
       #

--- a/lib/ronin/web/browser/agent.rb
+++ b/lib/ronin/web/browser/agent.rb
@@ -53,12 +53,16 @@ module Ronin
         # @param [String, nil] url
         #   Provides url for browser to navigate to after initialization.
         #
+        # @param [Hash{Symbol => Object}, Ferrum::Cookies::Cookie, nil] cookie
+        #   Provides cookie to set for browser after initialization.
+        #
         # @param [Hash{Symbol => Object}] kwargs
         #   Additional keyword arguments for `Ferrum::Browser#initialize`.
         #
         def initialize(visible:  false,
                        headless: !visible,
                        proxy:    Ronin::Support::Network::HTTP.proxy,
+                       cookie:   nil,
                        url:      nil,
                        **kwargs)
           proxy = case proxy
@@ -87,6 +91,8 @@ module Ronin
           @proxy    = proxy
 
           super(headless: headless, proxy: proxy, **kwargs)
+
+          cookies.set(cookie) if cookie
           go_to(url) if url
         end
 

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -33,6 +33,37 @@ describe Ronin::Web::Browser::Agent do
       after { subject.quit }
     end
 
+    context "when given the cookie: keyword argument" do
+      subject { described_class.new(cookie: cookie) }
+
+      let(:name)        { '_foo_sess' }
+      let(:value)       { 'eyJmb28iOiJiYXIifQ:1pQcTx:UufiSnuPIjNs7zOAJS0UpqnyvRt7KET7BVes0I8LYbA' }
+      let(:domain)      { 'foo-app.com' }
+      let(:cookie_hash) { { "name" => name, "value" => value, "domain" => domain, "session" => true } }
+
+      context 'when the cookie is a hash' do
+        let(:cookie) { cookie_hash }
+
+        it 'sets the cookie with the correct attributes' do
+          result = subject.cookies[name]
+          expect(result).to be_a Ferrum::Cookies::Cookie
+          expect(result.attributes > cookie).to be true
+        end
+      end
+
+      context 'when the cookie is a Cookie instance' do
+        let(:cookie) { Ferrum::Cookies::Cookie.new(**cookie_hash) }
+
+        it 'sets the cookie with the correct attributes' do
+          result = subject.cookies[name]
+          expect(result).to be_a Ferrum::Cookies::Cookie
+          expect(result.attributes > cookie_hash).to be true
+        end
+      end
+
+      after { subject.quit }
+    end
+
     context "when given the proxy: keyword argument" do
       let(:proxy_host) { 'example.com' }
       let(:proxy_port) { 8080 }


### PR DESCRIPTION
Addresses issue #17 by adding a cookie kwarg to set after browser initialization. Went with the singular ```cookie``` as the description of the issue suggested this would be used for the session cookie. Just let me know if this should support an array of cookies to set or, of course, if any other changes are required.