### PR TITLE
Add cookie_file kwarg to Ronin::Web::Browser::Agent initializer

### DIFF
--- a/lib/ronin/web/browser.rb
+++ b/lib/ronin/web/browser.rb
@@ -118,6 +118,9 @@ module Ronin
       # @option kwargs [Boolean] :headless (true)
       #   Controls whether the browser will start in headless or visible mode.
       #
+      # @option kwargs [String, nil] :cookie_file
+      #   Provides path to file containing cookies to load and set for browser.
+      #
       # @option kwargs [Hash{Symbol => Object}, Ferrum::Cookies::Cookie, nil] :cookie
       #   Provides cookie to set for browser after initialization.
       #

--- a/lib/ronin/web/browser/agent.rb
+++ b/lib/ronin/web/browser/agent.rb
@@ -51,20 +51,24 @@ module Ronin
         # @param [String, URI::HTTP, Addressible::URI, Hash, nil] proxy
         #   The proxy to send all browser requests through.
         #
-        # @param [String, nil] url
-        #   Provides url for browser to navigate to after initialization.
+        # @param [String, nil] cookie_file
+        #   Provides path to file containing cookies to load and set for browser.
         #
         # @param [Hash{Symbol => Object}, Ferrum::Cookies::Cookie, nil] cookie
         #   Provides cookie to set for browser after initialization.
         #
+        # @param [String, nil] url
+        #   Provides url for browser to navigate to after initialization.
+        #
         # @param [Hash{Symbol => Object}] kwargs
         #   Additional keyword arguments for `Ferrum::Browser#initialize`.
         #
-        def initialize(visible:  false,
-                       headless: !visible,
-                       proxy:    Ronin::Support::Network::HTTP.proxy,
-                       cookie:   nil,
-                       url:      nil,
+        def initialize(visible:      false,
+                       headless:     !visible,
+                       proxy:        Ronin::Support::Network::HTTP.proxy,
+                       cookie_file:  nil,
+                       cookie:       nil,
+                       url:          nil,
                        **kwargs)
           proxy = case proxy
                   when Hash, nil then proxy
@@ -93,6 +97,7 @@ module Ronin
 
           super(headless: headless, proxy: proxy, **kwargs)
 
+          load_cookies(cookie_file) if cookie_file
           cookies.set(cookie) if cookie
           go_to(url) if url
         end

--- a/lib/ronin/web/browser/mixin.rb
+++ b/lib/ronin/web/browser/mixin.rb
@@ -43,6 +43,9 @@ module Ronin
         # @option kwargs [Boolean] :headless (true)
         #   Controls whether the browser will start in headless or visible mode.
         #
+        # @option kwargs [String, nil] :cookie_file
+        #   Provides path to file containing cookies to load and set for browser.
+        #
         # @option kwargs [Hash{Symbol => Object}, Ferrum::Cookies::Cookie, nil] :cookie
         #   Provides cookie to set for browser after initialization.
         #

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -33,6 +33,31 @@ describe Ronin::Web::Browser::Agent do
       after { subject.quit }
     end
 
+    context "when given the cookie_file: keyword argument" do
+      let(:fixtures_dir) { File.join(__dir__,'fixtures') }
+      let(:cookie_file) { File.join(fixtures_dir,'cookies.txt') }
+
+      subject { described_class.new(cookie_file: cookie_file) }
+
+      it "must parse and load all cookies from the cookie file" do
+        cookies = subject.cookies.to_a
+
+        expect(cookies).to all(be_kind_of(Ferrum::Cookies::Cookie))
+        expect(cookies.length).to eq(2)
+        expect(cookies[0].name).to eq('foo')
+        expect(cookies[0].value).to eq('bar')
+        expect(cookies[0].domain).to eq('example.com')
+        expect(cookies[0].secure?).to be(true)
+
+        expect(cookies[1].name).to eq('baz')
+        expect(cookies[1].value).to eq('qux')
+        expect(cookies[1].domain).to eq('other.com')
+        expect(cookies[1].http_only?).to be(true)
+      end
+
+      after { subject.quit }
+    end
+
     context "when given the cookie: keyword argument" do
       subject { described_class.new(cookie: cookie) }
 


### PR DESCRIPTION
As described in issue #22 this PR adds the cookie_file kwarg to the Ronin::Web::Browser::Agent initializer, which accepts a string with the path to a cookie file. If provided, the initializer will call #load_cookies with this string. 

Also adds @option yard comments to the browser and mixin for the additional kwarg. 